### PR TITLE
Improve grade styling on Safari and mobile

### DIFF
--- a/web/src/lib/app.css
+++ b/web/src/lib/app.css
@@ -16,3 +16,7 @@
         color: var(--color-slate-100);
     }
 }
+
+@utility text-align-last-center {
+    text-align-last: center;
+}

--- a/web/src/lib/components/GradeSelector.svelte
+++ b/web/src/lib/components/GradeSelector.svelte
@@ -15,8 +15,7 @@
      class:bg-amber-500={grade === 'C'}
      class:bg-red-500={grade === 'D'}>
 
-    <select class="block w-9 h-full appearance-none bg-transparent outline-0 text-center text-white cursor-pointer"
-            style="text-align-last: center"
+    <select class="block w-9 h-full appearance-none bg-transparent outline-0 text-center text-align-last-center text-white cursor-pointer"
             bind:value={grade}>
         <option value={null}></option>
         <option value="A" class="text-blue-600">A</option>

--- a/web/src/lib/components/GradeSelector.svelte
+++ b/web/src/lib/components/GradeSelector.svelte
@@ -15,7 +15,7 @@
      class:bg-amber-500={grade === 'C'}
      class:bg-red-500={grade === 'D'}>
 
-    <select class="block w-9 h-full appearance-none bg-transparent text-center text-white cursor-pointer"
+    <select class="block w-9 h-full appearance-none bg-transparent outline-0 text-center text-white cursor-pointer"
             style="text-align-last: center"
             bind:value={grade}>
         <option value={null}></option>

--- a/web/src/lib/components/GradeSelector.svelte
+++ b/web/src/lib/components/GradeSelector.svelte
@@ -16,6 +16,7 @@
      class:bg-red-500={grade === 'D'}>
 
     <select class="block w-9 h-full appearance-none bg-transparent text-center text-white cursor-pointer"
+            style="text-align-last: center"
             bind:value={grade}>
         <option value={null}></option>
         <option value="A" class="text-blue-600">A</option>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the visual alignment of the grade selection dropdown by centering the text and removing the default focus outline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->