### PR TITLE
Compute telemetry stats server-side

### DIFF
--- a/internal/utils/telemetry_log.go
+++ b/internal/utils/telemetry_log.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/mileusna/useragent"
-	"io"
 	"net"
 	"net/http"
 	"os"
@@ -16,7 +15,7 @@ import (
 
 const logFile = "./data/parser.log"
 
-var mu sync.Mutex
+var telemetryMutex sync.Mutex
 
 type parseTelemetry struct {
 	Success         bool            `json:"success"`
@@ -38,8 +37,8 @@ type userAgent struct {
 // appendLog serializes the provided content to JSON and appends it to the log file
 func appendLog(telemetry parseTelemetry) error {
 	// Lock Mutex
-	mu.Lock()
-	defer mu.Unlock()
+	telemetryMutex.Lock()
+	defer telemetryMutex.Unlock()
 
 	// Create append stream to file
 	file, err := os.OpenFile(logFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
@@ -139,33 +138,4 @@ func LogParseTelemetry(req *http.Request, timings *ProcessTiming, error *APIErro
 		Error:           errorMessage,
 		UserAgent:       ua,
 	})
-}
-
-// ReadTelemetry reads the raw content of the log file and returns it as a byte slice
-func ReadTelemetry() (*[]byte, error) {
-	// Lock Mutex
-	mu.Lock()
-	defer mu.Unlock()
-
-	// Open log file
-	file, err := os.Open(logFile)
-	if err != nil {
-		return nil, err
-	}
-
-	// Close file when done
-	defer func(file *os.File) {
-		err := file.Close()
-		if err != nil {
-			fmt.Println("error while closing log file", err)
-		}
-	}(file)
-
-	// Read file content
-	telemetry, err := io.ReadAll(file)
-	if err != nil {
-		return nil, err
-	}
-
-	return &telemetry, nil
 }

--- a/internal/utils/telemetry_stats.go
+++ b/internal/utils/telemetry_stats.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// ReadTelemetry reads the raw content of the log file and returns it as a byte slice
+func ReadTelemetry() (*[]byte, error) {
+	// Lock Mutex
+	telemetryMutex.Lock()
+	defer telemetryMutex.Unlock()
+
+	// Open log file
+	file, err := os.Open(logFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// Close file when done
+	defer func(file *os.File) {
+		err := file.Close()
+		if err != nil {
+			fmt.Println("error while closing log file", err)
+		}
+	}(file)
+
+	// Read file content
+	telemetry, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+
+	return &telemetry, nil
+}

--- a/internal/utils/telemetry_stats.go
+++ b/internal/utils/telemetry_stats.go
@@ -91,7 +91,7 @@ func ComputeTelemetryStats(telemetry *[]parseTelemetry) TelemetryStats {
 		uniqueIPs[entry.ClientIP] = struct{}{}
 
 		// Parse timestamp string to time.Time
-		timestamp, err := time.Parse(time.RFC3339, entry.Timestamp)
+		timestamp, err := time.Parse(time.DateTime, entry.Timestamp)
 		isRecentEntry := false
 		if err == nil {
 			isRecentEntry = timestamp.After(oneWeekAgo)

--- a/internal/utils/telemetry_stats.go
+++ b/internal/utils/telemetry_stats.go
@@ -21,6 +21,9 @@ type TelemetryStats struct {
 	MaxPdfSizeKb            int64            `json:"maxPdfSizeKb"`
 	AverageParseTime        float64          `json:"averageParseTime"`
 	AverageParseTime95th    float64          `json:"averageParseTime95th"`
+	UAOSs                   map[string]int64 `json:"UAOSs"`
+	UABrowsers              map[string]int64 `json:"UABrowsers"`
+	UAPlatforms             map[string]int64 `json:"UAPlatforms"`
 	LatestSuccessfulParses  []parseTelemetry `json:"latestSuccessfulParses"`
 	LatestFailedParses      []parseTelemetry `json:"latestFailedParses"`
 }
@@ -84,6 +87,11 @@ func ComputeTelemetryStats(telemetry *[]parseTelemetry) TelemetryStats {
 	uniqueIPs := make(map[string]struct{})
 	uniqueIPsLastWeek := make(map[string]struct{})
 
+	// Maps for user agent statistics
+	uaOSs := make(map[string]int64)
+	uaBrowsers := make(map[string]int64)
+	uaPlatforms := make(map[string]int64)
+
 	// Collect parse durations for percentile calculation
 	var parseDurations []float64
 
@@ -125,6 +133,17 @@ func ComputeTelemetryStats(telemetry *[]parseTelemetry) TelemetryStats {
 		totalPdfSizeKb += entry.ContentLengthKB
 		if entry.ContentLengthKB > maxPdfSizeKb {
 			maxPdfSizeKb = entry.ContentLengthKB
+		}
+
+		// Track user agent statistics
+		if entry.UserAgent.OS != "" {
+			uaOSs[entry.UserAgent.OS]++
+		}
+		if entry.UserAgent.Browser != "" {
+			uaBrowsers[entry.UserAgent.Browser]++
+		}
+		if entry.UserAgent.Platform != "" {
+			uaPlatforms[entry.UserAgent.Platform]++
 		}
 	}
 
@@ -202,6 +221,9 @@ func ComputeTelemetryStats(telemetry *[]parseTelemetry) TelemetryStats {
 		MaxPdfSizeKb:            maxPdfSizeKb,
 		AverageParseTime:        averageParseTime,
 		AverageParseTime95th:    averageParseTime95th,
+		UAOSs:                   uaOSs,
+		UABrowsers:              uaBrowsers,
+		UAPlatforms:             uaPlatforms,
 		LatestSuccessfulParses:  latestSuccessfulParses,
 		LatestFailedParses:      latestFailedParses,
 	}

--- a/internal/utils/telemetry_stats.go
+++ b/internal/utils/telemetry_stats.go
@@ -11,16 +11,16 @@ import (
 )
 
 type TelemetryStats struct {
-	TotalParses             int     `json:"total_parses"`
-	TotalParsesOverLastWeek int     `json:"total_parses_over_last_week"`
-	UniqueUsers             int     `json:"unique_users"`
-	UniqueUsersOverLastWeek int     `json:"unique_users_over_last_week"`
-	ErrorRate               float64 `json:"error_rate"`
-	ErrorsOverLastWeek      int     `json:"errors_over_last_week"`
-	AveragePdfSize          float64 `json:"average_pdf_size"`
-	MaxPdfSizeKb            int64   `json:"max_pdf_size_kb"`
-	AverageParseTime        float64 `json:"average_parse_time"`
-	AverageParseTime95th    float64 `json:"average_parse_time_95th"`
+	TotalParses             int     `json:"totalParses"`
+	TotalParsesOverLastWeek int     `json:"totalParsesOverLastWeek"`
+	UniqueUsers             int     `json:"uniqueUsers"`
+	UniqueUsersOverLastWeek int     `json:"uniqueUsersOverLastWeek"`
+	ErrorRate               float64 `json:"errorRate"`
+	ErrorsOverLastWeek      int     `json:"errorsOverLastWeek"`
+	AveragePdfSizeKb        float64 `json:"averagePdfSizeKb"`
+	MaxPdfSizeKb            int64   `json:"maxPdfSizeKb"`
+	AverageParseTime        float64 `json:"averageParseTime"`
+	AverageParseTime95th    float64 `json:"averageParseTime95th"`
 }
 
 // ReadTelemetry reads the raw content of the log file and returns it as a slice of parseTelemetry structs
@@ -183,7 +183,7 @@ func ComputeTelemetryStats(telemetry *[]parseTelemetry) TelemetryStats {
 		UniqueUsersOverLastWeek: len(uniqueIPsLastWeek),
 		ErrorRate:               errorRate,
 		ErrorsOverLastWeek:      errorsOverLastWeek,
-		AveragePdfSize:          averagePdfSizeKb,
+		AveragePdfSizeKb:        averagePdfSizeKb,
 		MaxPdfSizeKb:            maxPdfSizeKb,
 		AverageParseTime:        averageParseTime,
 		AverageParseTime95th:    averageParseTime95th,

--- a/internal/utils/telemetry_stats.go
+++ b/internal/utils/telemetry_stats.go
@@ -1,13 +1,31 @@
 package utils
 
 import (
+	"bufio"
+	"encoding/json"
 	"fmt"
-	"io"
+	"math"
 	"os"
+	"sort"
+	"time"
 )
 
-// ReadTelemetry reads the raw content of the log file and returns it as a byte slice
-func ReadTelemetry() (*[]byte, error) {
+type TelemetryStats struct {
+	TotalParses             int     `json:"total_parses"`
+	TotalParsesOverLastWeek int     `json:"total_parses_over_last_week"`
+	UniqueUsers             int     `json:"unique_users"`
+	UniqueUsersOverLastWeek int     `json:"unique_users_over_last_week"`
+	ErrorRate               float64 `json:"error_rate"`
+	ErrorsOverLastWeek      int     `json:"errors_over_last_week"`
+	AveragePdfSize          float64 `json:"average_pdf_size"`
+	MaxPdfSizeKb            int64   `json:"max_pdf_size_kb"`
+	AverageParseTime        float64 `json:"average_parse_time"`
+	AverageParseTime95th    float64 `json:"average_parse_time_95th"`
+}
+
+// ReadTelemetry reads the raw content of the log file and returns it as a slice of parseTelemetry structs
+// It locks the telemetryMutex to ensure thread safety while reading the file.
+func ReadTelemetry() (*[]parseTelemetry, error) {
 	// Lock Mutex
 	telemetryMutex.Lock()
 	defer telemetryMutex.Unlock()
@@ -26,11 +44,148 @@ func ReadTelemetry() (*[]byte, error) {
 		}
 	}(file)
 
-	// Read file content
-	telemetry, err := io.ReadAll(file)
-	if err != nil {
-		return nil, err
+	// Read file content line by line
+	scanner := bufio.NewScanner(file)
+	var telemetry []parseTelemetry
+	for scanner.Scan() {
+		var entry parseTelemetry
+		line := scanner.Text()
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal telemetry entry: %w", err)
+		}
+		telemetry = append(telemetry, entry)
 	}
 
 	return &telemetry, nil
+}
+
+// ComputeTelemetryStats computes statistics from the telemetry data
+func ComputeTelemetryStats(telemetry *[]parseTelemetry) TelemetryStats {
+	if telemetry == nil || len(*telemetry) == 0 {
+		return TelemetryStats{}
+	}
+
+	data := *telemetry
+	oneWeekAgo := time.Now().AddDate(0, 0, -7)
+
+	// Initialize counters and accumulators
+	totalRecords := len(data)
+	lastWeekRecords := 0
+	totalErrors := 0
+	errorsOverLastWeek := 0
+	var totalPdfSizeKb int64
+	var maxPdfSizeKb int64
+	var totalParseDuration float64
+	successfulParses := 0
+
+	// Use maps for efficient unique user tracking
+	uniqueIPs := make(map[string]struct{})
+	uniqueIPsLastWeek := make(map[string]struct{})
+
+	// Collect parse durations for percentile calculation
+	var parseDurations []float64
+
+	// Single pass through data for efficiency
+	for _, entry := range data {
+		// Track unique users
+		uniqueIPs[entry.ClientIP] = struct{}{}
+
+		// Parse timestamp string to time.Time
+		timestamp, err := time.Parse(time.RFC3339, entry.Timestamp)
+		isRecentEntry := false
+		if err == nil {
+			isRecentEntry = timestamp.After(oneWeekAgo)
+		}
+
+		if isRecentEntry {
+			lastWeekRecords++
+			uniqueIPsLastWeek[entry.ClientIP] = struct{}{}
+		}
+
+		// Track errors
+		if !entry.Success {
+			totalErrors++
+			if isRecentEntry {
+				errorsOverLastWeek++
+			}
+		} else {
+			// Calculate total duration for successful parses
+			var entryDuration float64
+			for _, timing := range entry.Timings {
+				entryDuration += timing.Duration
+			}
+			totalParseDuration += entryDuration
+			parseDurations = append(parseDurations, entryDuration)
+			successfulParses++
+		}
+
+		// Track PDF sizes
+		totalPdfSizeKb += entry.ContentLengthKB
+		if entry.ContentLengthKB > maxPdfSizeKb {
+			maxPdfSizeKb = entry.ContentLengthKB
+		}
+	}
+
+	// Calculate derived statistics
+	var errorRate float64
+	if totalRecords > 0 {
+		errorRate = float64(math.Round(float64(totalErrors)/float64(totalRecords)*10000)) / 100
+	}
+
+	var averagePdfSizeKb float64
+	if totalRecords > 0 {
+		averagePdfSizeKb = float64(totalPdfSizeKb) / float64(totalRecords)
+	}
+
+	var averageParseTime float64
+	if successfulParses > 0 {
+		averageParseTime = totalParseDuration / float64(successfulParses)
+	}
+
+	// Calculate 95th percentile parse time
+	var averageParseTime95th float64
+	if len(parseDurations) > 0 {
+		sort.Slice(parseDurations, func(i, j int) bool {
+			return parseDurations[i] < parseDurations[j]
+		})
+
+		percentile95Index := int(math.Floor(float64(len(parseDurations)) * 0.95))
+		if percentile95Index < len(parseDurations) {
+			top5Percent := parseDurations[percentile95Index:]
+			var sum float64
+			for _, duration := range top5Percent {
+				sum += duration
+			}
+			if len(top5Percent) > 0 {
+				averageParseTime95th = sum / float64(len(top5Percent))
+			}
+		}
+	}
+
+	// Handle NaN values
+	if math.IsNaN(errorRate) {
+		errorRate = 0
+	}
+	if math.IsNaN(averagePdfSizeKb) {
+		averagePdfSizeKb = 0
+	}
+	if math.IsNaN(averageParseTime) {
+		averageParseTime = 0
+	}
+	if math.IsNaN(averageParseTime95th) {
+		averageParseTime95th = 0
+	}
+
+	return TelemetryStats{
+		TotalParses:             totalRecords,
+		TotalParsesOverLastWeek: lastWeekRecords,
+		UniqueUsers:             len(uniqueIPs),
+		UniqueUsersOverLastWeek: len(uniqueIPsLastWeek),
+		ErrorRate:               errorRate,
+		ErrorsOverLastWeek:      errorsOverLastWeek,
+		AveragePdfSize:          averagePdfSizeKb,
+		MaxPdfSizeKb:            maxPdfSizeKb,
+		AverageParseTime:        averageParseTime,
+		AverageParseTime95th:    averageParseTime95th,
+	}
 }

--- a/web/src/lib/components/telemetry/TelemetryParse.svelte
+++ b/web/src/lib/components/telemetry/TelemetryParse.svelte
@@ -21,7 +21,7 @@
     {/if}
 
     <div class="flex flex-col md:flex-row md:gap-2">
-        <div>[{unit.timestamp.toLocaleString()}] {unit.source} ({unit.contentLengthKB} KB)</div>
+        <div>[{new Date(unit.timestamp).toLocaleString()}] {unit.source} ({unit.contentLengthKB} KB)</div>
 
         <div class="hidden md:block">-</div>
 

--- a/web/src/lib/components/telemetry/TelemetryParsesList.svelte
+++ b/web/src/lib/components/telemetry/TelemetryParsesList.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
     import { telemetryState, type TelemetryUnit } from '$lib/state/telemetry.svelte.js';
     import TelemetryParse from '$lib/components/telemetry/TelemetryParse.svelte';
-
-    let successfulParses = $derived(telemetryState.telemetry.filter(t => t.success));
-    let failedParses = $derived(telemetryState.telemetry.filter(t => !t.success));
 </script>
 
 
@@ -27,6 +24,6 @@
 
 
 <div class="grid sm:gap-4 gap-2 2xl:grid-cols-2">
-    {@render parsesList('Latest successful parses', successfulParses)}
-    {@render parsesList('Latest failed parses', failedParses)}
+    {@render parsesList('Latest successful parses', telemetryState.stats?.latestSuccessfulParses || [])}
+    {@render parsesList('Latest failed parses', telemetryState.stats?.latestFailedParses || [])}
 </div>

--- a/web/src/lib/components/telemetry/TelemetryPieStatCard.svelte
+++ b/web/src/lib/components/telemetry/TelemetryPieStatCard.svelte
@@ -3,26 +3,23 @@
 
     interface Props {
         label: string;
-        values: string[];
+        values: Record<string, number>;
     }
 
     let { label, values }: Props = $props();
 
-    let aggregatedValues: Record<string, number> = $derived((() => {
-        const counts: Record<string, number> = {};
-        for (const value of values) {
-            counts[value] = (counts[value] || 0) + 1;
-        }
-
+    let sortedValues: Record<string, number> = $derived((() => {
         // Sort the keys in descending order of their counts
-        const sortedKeys = Object.keys(counts).sort((a, b) => counts[b] - counts[a]);
+        const sortedKeys = Object.keys(values).sort((a, b) => values[b] - values[a]);
         const sortedCounts: Record<string, number> = {};
         for (const key of sortedKeys) {
-            sortedCounts[key] = counts[key];
+            sortedCounts[key] = values[key];
         }
 
         return sortedCounts;
     })());
+
+    let totalDeviceCount = $derived(Object.values(values).reduce((a, b) => a + b, 0));
 
     const colors = [
         'red',
@@ -56,22 +53,23 @@
 
 <div class="flex items-center justify-center flex-col bg-slate-100 dark:bg-slate-700 p-2 sm:p-4 rounded-sm shadow-sm gap-2 sm:gap-4">
     <p class="text-center font-bold">{label}</p>
-    {#if values.length === 0}
+    {#if totalDeviceCount === 0}
         <p class="text-center text-sm text-gray-500">No data available</p>
     {:else}
         <div class="w-full max-w-sm grid grid-cols-2">
             <div class="justify-self-center relative aspect-square w-32">
-                {#each Object.entries(aggregatedValues).slice(0, 8) as [ value, count ], idx}
-                    {@const countUntilLast = Object.values(aggregatedValues).slice(0, idx).reduce((a, b) => a + b, 0)}
-                    <div class="absolute w-full h-full inset-0 rounded-full" style="
-                    background: conic-gradient({colorsThemes[idx]} calc({count / values.length} * 360deg), transparent 0);
-                    rotate: {(countUntilLast / values.length) * 360}deg;
-                "></div>
+                {#each Object.entries(sortedValues).slice(0, 8) as [ _, count ], idx}
+                    {@const countUntilLast = Object.values(sortedValues).slice(0, idx).reduce((a, b) => a + b, 0)}
+                    <div class="absolute w-full h-full inset-0 rounded-full"
+                         style="
+                             background: conic-gradient({colorsThemes[idx]} calc({count / totalDeviceCount} * 360deg), transparent 0);
+                             rotate: {(countUntilLast / totalDeviceCount) * 360}deg;
+                         "></div>
                 {/each}
             </div>
 
             <div class="justify-self-center flex flex-col justify-center gap-1">
-                {#each Object.entries(aggregatedValues).slice(0, 8) as [ value, count ], idx}
+                {#each Object.entries(sortedValues).slice(0, 8) as [ value, count ], idx}
                     <div class="flex items-center gap-2">
                         <div class="w-4 h-4 rounded-full" style="background-color: {colorsThemes[idx]}"></div>
                         <span class="text-sm">{value || 'Unknown'} ({count})</span>

--- a/web/src/lib/components/telemetry/TelemetryTimingStatsCard.svelte
+++ b/web/src/lib/components/telemetry/TelemetryTimingStatsCard.svelte
@@ -1,45 +1,9 @@
 <script lang="ts">
     import { telemetryState } from '$lib/state/telemetry.svelte.js';
 
-    // Group the durations of the timings by their key
-    const accumulatedStats = $derived(telemetryState.telemetry.reduce(
-        function (accParse, parse) {
-            if (!parse.success || !parse.timings) {
-                return accParse;
-            }
-
-            return parse.timings.reduce((acc, timing) => {
-                if (acc[timing.name] === undefined) {
-                    acc[timing.name] = [];
-                }
-                acc[timing.name].push(timing.duration);
-                return acc;
-            }, accParse);
-        },
-        {} as Record<string, number[]>,
-    ));
-
-    // Make the average of the durations for each key
-    const accumulatedStatsAverage = $derived(Object.entries(accumulatedStats).reduce(
-        (acc, [ key, values ]) => {
-            acc[key] = values.reduce((sum, value) => sum + value, 0) / values.length;
-            return acc;
-        },
-        {} as Record<string, number>,
-    ));
-
     // Total average duration across all timings
     const totalAverageDuration = $derived(
-        Object.values(accumulatedStatsAverage).reduce((sum, value) => sum + value, 0),
-    );
-
-    // Take the element with the most keys to get the order of the keys, along with their description
-    const timingKeys = $derived(telemetryState
-        .telemetry
-        .filter(t => t.success && t.timings)
-        .sort((a, b) => b.timings.length - a.timings.length)
-        [0]
-        ?.timings ?? [],
+        Object.values(telemetryState.stats?.timingAverageDuration ?? {}).reduce((sum, value) => sum + value, 0),
     );
 </script>
 
@@ -48,38 +12,39 @@
     <div class="text-center font-bold mb-2 md:mb-4">Timing Statistics</div>
 
     <div class="flex flex-col md:flex-row flex-1 w-full gap-0.5">
-        {#if timingKeys.length === 0}
+        {#if !telemetryState.stats || telemetryState.stats.timingKeys.length === 0}
             <div class="text-sm text-gray-500 dark:text-gray-400 w-full text-center">
                 No timing data available
             </div>
+        {:else}
+            {#each telemetryState.stats.timingKeys as { name, description }, idx (name)}
+                {@const stats = telemetryState.stats.timingAverageDuration[name]}
+                {@const duration = `${stats.toFixed(2)}ms`}
+                {@const fraction = (stats / totalAverageDuration * 100).toFixed(2)}
+
+                <div class="text-sm py-4 text-center md:w-(--fraction) h-(--fraction) md:h-auto flex md:flex-col gap-1 items-center justify-center overflow-clip"
+                     class:bg-red-300={idx === 0}
+                     class:bg-orange-300={idx === 1}
+                     class:bg-yellow-300={idx === 2}
+                     class:bg-green-300={idx === 3}
+                     class:bg-blue-300={idx === 4}
+                     class:bg-purple-300={idx === 5}
+                     class:bg-pink-300={idx === 6}
+                     class:bg-gray-300={idx >= 7}
+                     class:dark:bg-red-500={idx === 0}
+                     class:dark:bg-orange-500={idx === 1}
+                     class:dark:bg-yellow-500={idx === 2}
+                     class:dark:bg-green-500={idx === 3}
+                     class:dark:bg-blue-500={idx === 4}
+                     class:dark:bg-purple-500={idx === 5}
+                     class:dark:bg-pink-500={idx === 6}
+                     class:dark:bg-gray-500={idx >= 7}
+                     title="{description} ({duration})"
+                     style="--fraction: {fraction}%">
+                    <div class="line-clamp-1">{description}</div>
+                    <div class="line-clamp-1">({duration})</div>
+                </div>
+            {/each}
         {/if}
-
-        {#each timingKeys as { name, description }, idx (name)}
-            {@const duration = `${accumulatedStatsAverage[name].toFixed(2)}ms`}
-            {@const fraction = (accumulatedStatsAverage[name] / totalAverageDuration * 100).toFixed(2)}
-
-            <div class="text-sm py-4 text-center md:w-(--fraction) h-(--fraction) md:h-auto flex md:flex-col gap-1 items-center justify-center overflow-clip"
-                 class:bg-red-300={idx === 0}
-                 class:bg-orange-300={idx === 1}
-                 class:bg-yellow-300={idx === 2}
-                 class:bg-green-300={idx === 3}
-                 class:bg-blue-300={idx === 4}
-                 class:bg-purple-300={idx === 5}
-                 class:bg-pink-300={idx === 6}
-                 class:bg-gray-300={idx >= 7}
-                 class:dark:bg-red-500={idx === 0}
-                 class:dark:bg-orange-500={idx === 1}
-                 class:dark:bg-yellow-500={idx === 2}
-                 class:dark:bg-green-500={idx === 3}
-                 class:dark:bg-blue-500={idx === 4}
-                 class:dark:bg-purple-500={idx === 5}
-                 class:dark:bg-pink-500={idx === 6}
-                 class:dark:bg-gray-500={idx >= 7}
-                 title="{description} ({duration})"
-                 style="--fraction: {fraction}%">
-                <div class="line-clamp-1">{description}</div>
-                <div class="line-clamp-1">({duration})</div>
-            </div>
-        {/each}
     </div>
 </div>

--- a/web/src/lib/state/telemetry.svelte.ts
+++ b/web/src/lib/state/telemetry.svelte.ts
@@ -16,16 +16,16 @@ export interface UserAgent {
 }
 
 export interface TelemetryStats {
-    total_parses: number;
-    total_parses_over_last_week: number;
-    unique_users: number;
-    unique_users_over_last_week: number;
-    error_rate: number;
-    errors_over_last_week: number;
-    average_pdf_size: number;
-    max_pdf_size_kb: number;
-    average_parse_time: number;
-    average_parse_time_95th: number;
+    totalParses: number;
+    totalParsesOverLastWeek: number;
+    uniqueUsers: number;
+    uniqueUsersOverLastWeek: number;
+    errorRate: number;
+    errorsOverLastWeek: number;
+    averagePdfSizeKb: number;
+    maxPdfSizeKb: number;
+    averageParseTime: number;
+    averageParseTime95th: number;
 }
 
 export interface TimingElement {

--- a/web/src/lib/state/telemetry.svelte.ts
+++ b/web/src/lib/state/telemetry.svelte.ts
@@ -26,6 +26,9 @@ export interface TelemetryStats {
     maxPdfSizeKb: number;
     averageParseTime: number;
     averageParseTime95th: number;
+    UAOSs: Record<string, number>;
+    UABrowsers: Record<string, number>;
+    UAPlatforms: Record<string, number>;
     latestSuccessfulParses: TelemetryUnit[];
     latestFailedParses: TelemetryUnit[];
 }

--- a/web/src/lib/state/telemetry.svelte.ts
+++ b/web/src/lib/state/telemetry.svelte.ts
@@ -9,6 +9,25 @@ export interface TelemetryUnit {
     userAgent?: UserAgent;
 }
 
+export interface UserAgent {
+    os: string;
+    browser: string;
+    platform: string;
+}
+
+export interface TelemetryStats {
+    total_parses: number;
+    total_parses_over_last_week: number;
+    unique_users: number;
+    unique_users_over_last_week: number;
+    error_rate: number;
+    errors_over_last_week: number;
+    average_pdf_size: number;
+    max_pdf_size_kb: number;
+    average_parse_time: number;
+    average_parse_time_95th: number;
+}
+
 export interface TimingElement {
     name: string;
     description: string;
@@ -18,15 +37,11 @@ export interface TimingElement {
 export interface TelemetryState {
     loaded: boolean;
     telemetry: TelemetryUnit[];
-}
-
-export interface UserAgent {
-    os: string;
-    browser: string;
-    platform: string;
+    stats: TelemetryStats | null;
 }
 
 export const telemetryState = $state<TelemetryState>({
     loaded: false,
     telemetry: [],
+    stats: null,
 });

--- a/web/src/lib/state/telemetry.svelte.ts
+++ b/web/src/lib/state/telemetry.svelte.ts
@@ -9,6 +9,12 @@ export interface TelemetryUnit {
     userAgent?: UserAgent;
 }
 
+export interface TimingElement {
+    name: string;
+    description: string;
+    duration: number; // in milliseconds
+}
+
 export interface UserAgent {
     os: string;
     browser: string;
@@ -35,20 +41,12 @@ export interface TelemetryStats {
     timingKeys: { name: string, description: string }[];
 }
 
-export interface TimingElement {
-    name: string;
-    description: string;
-    duration: number; // in milliseconds
-}
-
 export interface TelemetryState {
     loaded: boolean;
-    telemetry: TelemetryUnit[];
     stats: TelemetryStats | null;
 }
 
 export const telemetryState = $state<TelemetryState>({
     loaded: false,
-    telemetry: [],
     stats: null,
 });

--- a/web/src/lib/state/telemetry.svelte.ts
+++ b/web/src/lib/state/telemetry.svelte.ts
@@ -31,6 +31,8 @@ export interface TelemetryStats {
     UAPlatforms: Record<string, number>;
     latestSuccessfulParses: TelemetryUnit[];
     latestFailedParses: TelemetryUnit[];
+    timingAverageDuration: Record<string, number>;
+    timingKeys: { name: string, description: string }[];
 }
 
 export interface TimingElement {

--- a/web/src/lib/state/telemetry.svelte.ts
+++ b/web/src/lib/state/telemetry.svelte.ts
@@ -1,6 +1,6 @@
 export interface TelemetryUnit {
     success: boolean;
-    timestamp: Date;
+    timestamp: string;
     clientIP: string;
     source: string;
     contentLengthKB: number;
@@ -26,6 +26,8 @@ export interface TelemetryStats {
     maxPdfSizeKb: number;
     averageParseTime: number;
     averageParseTime95th: number;
+    latestSuccessfulParses: TelemetryUnit[];
+    latestFailedParses: TelemetryUnit[];
 }
 
 export interface TimingElement {

--- a/web/src/lib/views/telemetry/Telemetry.svelte
+++ b/web/src/lib/views/telemetry/Telemetry.svelte
@@ -5,86 +5,36 @@
     import TelemetryParsesList from '$lib/components/telemetry/TelemetryParsesList.svelte';
     import TelemetryPieStatCard from '$lib/components/telemetry/TelemetryPieStatCard.svelte';
 
-    const isAWeekOld = (timestamp: Date) => timestamp.getTime() > Date.now() - 7 * 24 * 60 * 60 * 1000;
-    const zeroIfNaN = (value: number) => isNaN(value) ? 0 : value;
-
-    let totalRecords = $derived(telemetryState.telemetry.length);
-    let lastWeekRecords = $derived(
-        telemetryState.telemetry.filter(t => isAWeekOld(t.timestamp)).length,
-    );
-
-    let uniqueUsers = $derived(
-        telemetryState.telemetry
-            .map(t => t.clientIP)
-            .filter((value, index, self) => self.indexOf(value) === index).length,
-    );
-    let uniqueUsersOverLastWeek = $derived(
-        telemetryState.telemetry
-            .filter(t => isAWeekOld(t.timestamp))
-            .map(t => t.clientIP)
-            .filter((value, index, self) => self.indexOf(value) === index).length,
-    );
-
-    let totalErrors = $derived(
-        telemetryState.telemetry.filter((t) => !t.success).length,
-    );
-    let errorRate = $derived(Math.round(totalErrors / totalRecords * 1e4) / 1e2);
-    let errorsOverLastWeek = $derived(
-        telemetryState.telemetry.filter((t) => !t.success && isAWeekOld(t.timestamp)).length,
-    );
-
-    let averagePdfSize = $derived(
-        telemetryState.telemetry.reduce((acc, t) => acc + t.contentLengthKB, 0) / totalRecords,
-    );
-    let maxPdfSize = $derived(
-        telemetryState.telemetry.reduce((acc, t) => Math.max(acc, t.contentLengthKB), 0),
-    );
-
-    let averageParseDuration = $derived(
-        telemetryState
-            .telemetry
-            .filter(t => t.success)
-            .reduce(
-                (acc, t) => acc + t.timings.reduce((acc, t) => acc + t.duration, 0),
-                0,
-            ) / (totalRecords - totalErrors),
-    );
-    let percentile95ParseValues = $derived(
-        telemetryState.telemetry
-            .filter(t => t.success)
-            .map(t => t.timings.reduce((acc, t) => acc + t.duration, 0))
-            .sort((a, b) => a - b)
-            .slice(Math.floor((totalRecords - totalErrors) * 0.95)),
-    );
-    let percentile95ParseDuration = $derived(
-        percentile95ParseValues.reduce((acc, t) => acc + t, 0) / percentile95ParseValues.length,
-    );
-
     let userAgents = $derived(
         telemetryState.telemetry
             .map(t => t.userAgent)
             .filter(u => !!u),
     );
+
+    const round = (value: number | null | undefined, decimals: number = 0) => {
+        const factor = Math.pow(10, decimals);
+        return Math.round((value ?? 0) * factor) / factor;
+    };
 </script>
 
 
 <div class="grid sm:gap-4 gap-2 p-2 sm:p-4">
     <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-5 sm:gap-4 gap-2">
-        <TelemetryStatCard description="{lastWeekRecords} parse over last week"
+        <TelemetryStatCard description="{telemetryState.stats?.total_parses_over_last_week ?? 0} parse over last week"
                            label="Total Records"
-                           value={totalRecords}/>
-        <TelemetryStatCard description="{uniqueUsersOverLastWeek} over last week"
+                           value={telemetryState.stats?.total_parses ?? 0}/>
+        <TelemetryStatCard description="{telemetryState.stats?.errors_over_last_week ?? 0} over last week"
                            label="Unique Users"
-                           value={uniqueUsers}/>
-        <TelemetryStatCard description="{errorsOverLastWeek} errors over last week"
+                           value={telemetryState.stats?.unique_users ?? 0}/>
+        <TelemetryStatCard description="{telemetryState.stats?.unique_users_over_last_week ?? 0} errors over last week"
                            label="Error Rate"
-                           value="{zeroIfNaN(errorRate)} %"/>
-        <TelemetryStatCard description="Max: {maxPdfSize} KB"
+                           value="{round(telemetryState.stats?.error_rate, 1)} %"/>
+        <TelemetryStatCard description="Max: {telemetryState.stats?.max_pdf_size_kb} KB"
                            label="Average PDF Size"
-                           value="{Math.round(zeroIfNaN(averagePdfSize))} KB"/>
-        <TelemetryStatCard description="95th percentile: {Math.round(zeroIfNaN(percentile95ParseDuration))} ms"
+                           value="{round(telemetryState.stats?.average_pdf_size)} KB"/>
+        <TelemetryStatCard description="95th percentile: {round(telemetryState.stats?.average_parse_time_95th)} ms"
                            label="Average Duration"
-                           value="{Math.round(zeroIfNaN(averageParseDuration))} ms"/>
+                           value="{round(telemetryState.stats?.average_parse_time)} ms"/>
     </div>
 
     <div class="grid grid-cols-1 lg:grid-cols-3 sm:gap-4 gap-2">

--- a/web/src/lib/views/telemetry/Telemetry.svelte
+++ b/web/src/lib/views/telemetry/Telemetry.svelte
@@ -20,21 +20,21 @@
 
 <div class="grid sm:gap-4 gap-2 p-2 sm:p-4">
     <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-5 sm:gap-4 gap-2">
-        <TelemetryStatCard description="{telemetryState.stats?.total_parses_over_last_week ?? 0} parse over last week"
+        <TelemetryStatCard description="{telemetryState.stats?.totalParsesOverLastWeek ?? 0} parse over last week"
                            label="Total Records"
-                           value={telemetryState.stats?.total_parses ?? 0}/>
-        <TelemetryStatCard description="{telemetryState.stats?.errors_over_last_week ?? 0} over last week"
+                           value={telemetryState.stats?.totalParses ?? 0}/>
+        <TelemetryStatCard description="{telemetryState.stats?.errorsOverLastWeek ?? 0} over last week"
                            label="Unique Users"
-                           value={telemetryState.stats?.unique_users ?? 0}/>
-        <TelemetryStatCard description="{telemetryState.stats?.unique_users_over_last_week ?? 0} errors over last week"
+                           value={telemetryState.stats?.uniqueUsers ?? 0}/>
+        <TelemetryStatCard description="{telemetryState.stats?.uniqueUsersOverLastWeek ?? 0} errors over last week"
                            label="Error Rate"
-                           value="{round(telemetryState.stats?.error_rate, 1)} %"/>
-        <TelemetryStatCard description="Max: {telemetryState.stats?.max_pdf_size_kb} KB"
+                           value="{round(telemetryState.stats?.errorRate, 1)} %"/>
+        <TelemetryStatCard description="Max: {telemetryState.stats?.maxPdfSizeKb} KB"
                            label="Average PDF Size"
-                           value="{round(telemetryState.stats?.average_pdf_size)} KB"/>
-        <TelemetryStatCard description="95th percentile: {round(telemetryState.stats?.average_parse_time_95th)} ms"
+                           value="{round(telemetryState.stats?.averagePdfSizeKb)} KB"/>
+        <TelemetryStatCard description="95th percentile: {round(telemetryState.stats?.averageParseTime95th)} ms"
                            label="Average Duration"
-                           value="{round(telemetryState.stats?.average_parse_time)} ms"/>
+                           value="{round(telemetryState.stats?.averageParseTime)} ms"/>
     </div>
 
     <div class="grid grid-cols-1 lg:grid-cols-3 sm:gap-4 gap-2">

--- a/web/src/lib/views/telemetry/Telemetry.svelte
+++ b/web/src/lib/views/telemetry/Telemetry.svelte
@@ -5,12 +5,6 @@
     import TelemetryParsesList from '$lib/components/telemetry/TelemetryParsesList.svelte';
     import TelemetryPieStatCard from '$lib/components/telemetry/TelemetryPieStatCard.svelte';
 
-    let userAgents = $derived(
-        telemetryState.telemetry
-            .map(t => t.userAgent)
-            .filter(u => !!u),
-    );
-
     const round = (value: number | null | undefined, decimals: number = 0) => {
         const factor = Math.pow(10, decimals);
         return Math.round((value ?? 0) * factor) / factor;
@@ -38,9 +32,9 @@
     </div>
 
     <div class="grid grid-cols-1 lg:grid-cols-3 sm:gap-4 gap-2">
-        <TelemetryPieStatCard label="Operating System" values={userAgents.map(u => u.os)}/>
-        <TelemetryPieStatCard label="Browser" values={userAgents.map(u => u.browser)}/>
-        <TelemetryPieStatCard label="Platform" values={userAgents.map(u => u.platform)}/>
+        <TelemetryPieStatCard label="Operating System" values={telemetryState.stats?.UAOSs ?? {}}/>
+        <TelemetryPieStatCard label="Browser" values={telemetryState.stats?.UABrowsers ?? {}}/>
+        <TelemetryPieStatCard label="Platform" values={telemetryState.stats?.UAPlatforms ?? {}}/>
     </div>
 
     <TelemetryTimingStatsCard/>

--- a/web/src/lib/views/telemetry/Telemetry.svelte
+++ b/web/src/lib/views/telemetry/Telemetry.svelte
@@ -23,10 +23,10 @@
         <TelemetryStatCard description="{telemetryState.stats?.totalParsesOverLastWeek ?? 0} parse over last week"
                            label="Total Records"
                            value={telemetryState.stats?.totalParses ?? 0}/>
-        <TelemetryStatCard description="{telemetryState.stats?.errorsOverLastWeek ?? 0} over last week"
+        <TelemetryStatCard description="{telemetryState.stats?.uniqueUsersOverLastWeek ?? 0} over last week"
                            label="Unique Users"
                            value={telemetryState.stats?.uniqueUsers ?? 0}/>
-        <TelemetryStatCard description="{telemetryState.stats?.uniqueUsersOverLastWeek ?? 0} errors over last week"
+        <TelemetryStatCard description="{telemetryState.stats?.errorsOverLastWeek ?? 0} errors over last week"
                            label="Error Rate"
                            value="{round(telemetryState.stats?.errorRate, 1)} %"/>
         <TelemetryStatCard description="Max: {telemetryState.stats?.maxPdfSizeKb} KB"

--- a/web/src/routes/telemetry/+page.svelte
+++ b/web/src/routes/telemetry/+page.svelte
@@ -5,7 +5,7 @@
     import Telemetry from '$lib/views/telemetry/Telemetry.svelte';
     import { browser } from '$app/environment';
     import { onMount } from 'svelte';
-    import { telemetryState, type TelemetryUnit } from '$lib/state/telemetry.svelte';
+    import { telemetryState, type TelemetryStats } from '$lib/state/telemetry.svelte';
 
     const telemetryAuthKey = 'telemetry-auth';
 
@@ -35,7 +35,7 @@
             return;
         }
 
-        let data: TelemetryUnit[];
+        let data: TelemetryStats;
         try {
             const resJson = await res.json();
             if (resJson.error) {
@@ -48,10 +48,7 @@
             return;
         }
 
-        telemetryState.telemetry = data.map((d: any) => ({
-            ...d,
-            timestamp: new Date(d.timestamp),
-        }));
+        telemetryState.stats = data;
         telemetryState.loaded = true;
     }
 

--- a/web/src/routes/telemetry/+page.svelte
+++ b/web/src/routes/telemetry/+page.svelte
@@ -5,7 +5,7 @@
     import Telemetry from '$lib/views/telemetry/Telemetry.svelte';
     import { browser } from '$app/environment';
     import { onMount } from 'svelte';
-    import { telemetryState, type TelemetryStats } from '$lib/state/telemetry.svelte';
+    import { telemetryState } from '$lib/state/telemetry.svelte';
 
     const telemetryAuthKey = 'telemetry-auth';
 
@@ -35,21 +35,18 @@
             return;
         }
 
-        let data: TelemetryStats;
         try {
             const resJson = await res.json();
             if (resJson.error) {
                 error = resJson.error;
                 return;
             }
-            data = resJson.data;
+            telemetryState.stats = resJson.data;
+            telemetryState.loaded = true;
         } catch (e) {
             error = 'Failed to fetch telemetry data';
             return;
         }
-
-        telemetryState.stats = data;
-        telemetryState.loaded = true;
     }
 
     onMount(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry statistics are now displayed as aggregated summaries, including total parses, unique users, error rates, PDF size metrics, parse time averages, and user agent breakdowns.
  * Recent successful and failed parse entries are now shown directly from precomputed stats.

* **Improvements**
  * Telemetry dashboard components now use precomputed statistics, improving performance and consistency.
  * Pie chart and timing stats cards have updated logic to display data from aggregated stats.

* **Bug Fixes**
  * Timestamp formatting in telemetry parse entries is now more robust.

* **Refactor**
  * Internal logic for computing telemetry statistics has been centralized, simplifying component code and reducing duplication.

* **Chores**
  * Type definitions and state structures updated to support new telemetry statistics format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->