### PR TITLE
Sort latest parses in descending order

### DIFF
--- a/internal/utils/telemetry_stats.go
+++ b/internal/utils/telemetry_stats.go
@@ -242,9 +242,9 @@ func ComputeTelemetryStats(telemetry *[]parseTelemetry) TelemetryStats {
 	for i := len(data) - 1; i >= 0 && (len(latestSuccessfulParses) < maxLatestParses || len(latestFailedParses) < maxLatestParses); i-- {
 		entry := data[i]
 		if entry.Success && len(latestSuccessfulParses) < maxLatestParses {
-			latestSuccessfulParses = append(latestSuccessfulParses, entry)
+			latestSuccessfulParses = append([]parseTelemetry{entry}, latestSuccessfulParses...)
 		} else if !entry.Success && len(latestFailedParses) < maxLatestParses {
-			latestFailedParses = append(latestFailedParses, entry)
+			latestFailedParses = append([]parseTelemetry{entry}, latestFailedParses...)
 		}
 	}
 

--- a/internal/utils/telemetry_stats.go
+++ b/internal/utils/telemetry_stats.go
@@ -236,7 +236,7 @@ func ComputeTelemetryStats(telemetry *[]parseTelemetry) TelemetryStats {
 	}
 
 	// Prepare latest successful and error parses
-	const maxLatestParses = 25
+	const maxLatestParses = 15
 	latestSuccessfulParses := make([]parseTelemetry, 0, maxLatestParses)
 	latestFailedParses := make([]parseTelemetry, 0, maxLatestParses)
 	for i := len(data) - 1; i >= 0 && (len(latestSuccessfulParses) < maxLatestParses || len(latestFailedParses) < maxLatestParses); i-- {

--- a/internal/utils/telemetry_stats.go
+++ b/internal/utils/telemetry_stats.go
@@ -242,9 +242,9 @@ func ComputeTelemetryStats(telemetry *[]parseTelemetry) TelemetryStats {
 	for i := len(data) - 1; i >= 0 && (len(latestSuccessfulParses) < maxLatestParses || len(latestFailedParses) < maxLatestParses); i-- {
 		entry := data[i]
 		if entry.Success && len(latestSuccessfulParses) < maxLatestParses {
-			latestSuccessfulParses = append([]parseTelemetry{entry}, latestSuccessfulParses...)
+			latestSuccessfulParses = append(latestSuccessfulParses, entry)
 		} else if !entry.Success && len(latestFailedParses) < maxLatestParses {
-			latestFailedParses = append([]parseTelemetry{entry}, latestFailedParses...)
+			latestFailedParses = append(latestFailedParses, entry)
 		}
 	}
 

--- a/web/src/lib/components/telemetry/TelemetryParsesList.svelte
+++ b/web/src/lib/components/telemetry/TelemetryParsesList.svelte
@@ -15,7 +15,7 @@
                 </div>
             {/if}
 
-            {#each telemetry.slice(-25).toReversed() as unit}
+            {#each telemetry as unit}
                 <TelemetryParse {unit}/>
             {/each}
         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the telemetry display to show all entries in their original order instead of only the last 25 in reverse order.
  * Reduced the maximum number of stored telemetry parse entries from 25 to 15.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->